### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tests/test_ditem.py
+++ b/tests/test_ditem.py
@@ -4,6 +4,7 @@
 """Contains test cases for the DownloadItem object."""
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 import os.path
@@ -15,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(PATH)))
 try:
     from youtube_dl_gui.downloadmanager import DownloadItem
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 

--- a/tests/test_dlist.py
+++ b/tests/test_dlist.py
@@ -4,6 +4,7 @@
 """Contains test cases for the DownloadList object."""
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 import os.path
@@ -16,7 +17,7 @@ try:
     import mock
     from youtube_dl_gui.downloadmanager import DownloadList, synchronized
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -4,6 +4,7 @@
 """Contains test cases for the parsers module."""
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 import os.path
@@ -15,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(PATH)))
 try:
     from youtube_dl_gui.parsers import OptionsParser
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@
 """Contains test cases for the utils.py module."""
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 import os.path
@@ -17,7 +18,7 @@ try:
 
     from youtube_dl_gui import utils
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -4,6 +4,7 @@
 """Contains test cases for the widgets.py module."""
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 import os.path
@@ -23,7 +24,7 @@ try:
         ListBoxPopup
     )
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 

--- a/youtube_dl_gui/__init__.py
+++ b/youtube_dl_gui/__init__.py
@@ -15,6 +15,7 @@ Example:
 """
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 import gettext
@@ -23,7 +24,7 @@ import os.path
 try:
     import wx
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 __packagename__ = "youtube_dl_gui"

--- a/youtube_dl_gui/utils.py
+++ b/youtube_dl_gui/utils.py
@@ -11,6 +11,7 @@ Attributes:
 """
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import os
 import sys
@@ -22,7 +23,7 @@ import subprocess
 try:
     from twodict import TwoWayOrderedDict
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 from .info import __appname__

--- a/youtube_dl_gui/widgets.py
+++ b/youtube_dl_gui/widgets.py
@@ -2,13 +2,14 @@
 # -*- coding: UTF-8 -*-
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 
 try:
     import wx
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.